### PR TITLE
Use native macOS window controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "dashmap",
  "dirs",
  "image 0.25.10",
+ "objc",
  "open",
  "parking_lot",
  "raw-window-handle",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -69,5 +69,8 @@ raw-window-handle = "0.6"
 windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_Graphics_Gdi", "Win32_UI_WindowsAndMessaging"] }
 raw-window-handle = "0.6"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+
 [build-dependencies]
 slint-build = "1.15.1"

--- a/app/build.rs
+++ b/app/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(feature, values(\"cargo-clippy\"))");
     slint_build::compile("ui/app-window.slint").expect("Slint build failed");
 }

--- a/app/src/callbacks.rs
+++ b/app/src/callbacks.rs
@@ -19,6 +19,8 @@ use std::time::Duration;
 use tracing::{error, info, warn};
 
 const ACTION_ZOOM_FACTOR: f64 = ZOOM_FACTOR * ZOOM_FACTOR;
+#[cfg(target_os = "macos")]
+const MACOS_TOOLBAR_HEIGHT: f64 = 40.0;
 
 /// Query the cursor position in window-local physical pixels via X11.
 #[cfg(target_os = "linux")]
@@ -108,6 +110,94 @@ fn query_dnd_cursor_logical(ui: &AppWindow) -> Option<(f32, f32)> {
     let (px, py) = query_dnd_cursor_physical(ui)?;
     let scale = ui.window().scale_factor() as f64;
     Some(((px / scale) as f32, (py / scale) as f32))
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NSPoint {
+    x: f64,
+    y: f64,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NSSize {
+    width: f64,
+    height: f64,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NSRect {
+    origin: NSPoint,
+    size: NSSize,
+}
+
+#[cfg(target_os = "macos")]
+unsafe impl objc::Encode for NSPoint {
+    fn encode() -> objc::Encoding {
+        unsafe { objc::Encoding::from_str("{CGPoint=dd}") }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe impl objc::Encode for NSSize {
+    fn encode() -> objc::Encoding {
+        unsafe { objc::Encoding::from_str("{CGSize=dd}") }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe impl objc::Encode for NSRect {
+    fn encode() -> objc::Encoding {
+        unsafe { objc::Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}") }
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[allow(unexpected_cfgs)]
+fn align_macos_window_controls(slint_window: &slint::Window) {
+    use objc::runtime::Object;
+    use objc::{sel, sel_impl};
+    use slint::winit_030::WinitWindowAccessor;
+    use slint::winit_030::winit::raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    slint_window.with_winit_window(|w| {
+        let Ok(window_handle) = w.window_handle() else {
+            return;
+        };
+
+        let RawWindowHandle::AppKit(handle) = window_handle.as_ref() else {
+            return;
+        };
+
+        let ns_view = handle.ns_view.as_ptr().cast::<Object>();
+
+        unsafe {
+            let ns_window: *mut Object = objc::msg_send![ns_view, window];
+            if ns_window.is_null() {
+                return;
+            }
+
+            for button_kind in [0usize, 1, 2] {
+                let button: *mut Object =
+                    objc::msg_send![ns_window, standardWindowButton: button_kind];
+                if button.is_null() {
+                    continue;
+                }
+
+                let frame: NSRect = objc::msg_send![button, frame];
+                let origin = NSPoint {
+                    x: frame.origin.x,
+                    y: (MACOS_TOOLBAR_HEIGHT - frame.size.height) / 2.0,
+                };
+                let _: () = objc::msg_send![button, setFrameOrigin: origin];
+            }
+        }
+    });
 }
 
 fn frame_active_viewport(state: &mut AppState) -> bool {
@@ -1251,6 +1341,16 @@ pub fn setup_callbacks(
             if let Some(ui) = ui_weak.upgrade() {
                 let _ = ui.hide();
                 let _ = slint::quit_event_loop();
+            }
+        });
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let ui_weak = ui_weak.clone();
+        Timer::single_shot(Duration::from_millis(0), move || {
+            if let Some(ui) = ui_weak.upgrade() {
+                align_macos_window_controls(ui.window());
             }
         });
     }

--- a/app/src/callbacks.rs
+++ b/app/src/callbacks.rs
@@ -1420,7 +1420,11 @@ pub fn setup_callbacks(
                     } else {
                         0.0
                     };
-                    let buttons_right_start = win_w - 138.0;
+                    let buttons_right_start = if cfg!(target_os = "macos") {
+                        win_w
+                    } else {
+                        win_w - 138.0
+                    };
 
                     if ly < toolbar_height && lx >= toolbar_action_width && lx < buttons_right_start
                     {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -413,8 +413,7 @@ fn format_optional_decimal(value: Option<f64>) -> String {
 }
 
 fn select_backend() -> Result<bool> {
-    let gpu_result = BackendSelector::new()
-        .backend_name("winit".to_string())
+    let gpu_result = winit_backend_selector()
         .renderer_name("femtovg-wgpu".to_string())
         .require_wgpu_28(slint::wgpu_28::WGPUConfiguration::default())
         .select();
@@ -426,12 +425,32 @@ fn select_backend() -> Result<bool> {
                 "GPU backend unavailable, falling back to CPU renderer: {}",
                 err
             );
-            BackendSelector::new()
-                .backend_name("winit".to_string())
+            winit_backend_selector()
                 .renderer_name("femtovg".to_string())
                 .select()?;
             Ok(false)
         }
+    }
+}
+
+fn winit_backend_selector() -> BackendSelector {
+    let selector = BackendSelector::new().backend_name("winit".to_string());
+
+    #[cfg(target_os = "macos")]
+    {
+        use slint::winit_030::winit::platform::macos::WindowAttributesExtMacOS;
+
+        selector.with_winit_window_attributes_hook(|attributes| {
+            attributes
+                .with_titlebar_transparent(true)
+                .with_title_hidden(true)
+                .with_fullsize_content_view(true)
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        selector
     }
 }
 
@@ -650,6 +669,7 @@ fn main() -> Result<()> {
     ));
 
     let ui = AppWindow::new()?;
+    ui.set_use_native_window_controls(cfg!(target_os = "macos"));
     let ui_weak = ui.as_weak();
     let gpu_renderer = Rc::new(RefCell::new(GpuRenderer::new()));
     GpuRenderer::install(&ui, Rc::clone(&gpu_renderer))?;

--- a/app/ui/app-window.slint
+++ b/app/ui/app-window.slint
@@ -22,7 +22,8 @@ import { WindowToolbar } from "window-toolbar.slint";
 export component AppWindow inherits Window {
     title: "eov";
     icon: @image-url("../../images/logo_full.png");
-    no-frame: true;
+    in property <bool> use-native-window-controls: false;
+    no-frame: !use-native-window-controls;
     resize-border-width: 5px;
     min-width: 800px;
     min-height: 600px;
@@ -202,6 +203,7 @@ export component AppWindow inherits Window {
             gpu-rendering-available: root.gpu-rendering-available;
             show-minimap: root.show-minimap;
             show-metadata: root.show-metadata;
+            use-native-window-controls: root.use-native-window-controls;
             open-file-requested => { root.open-file-requested(); }
             open-recent-menu-requested(x, y) => { root.open-recent-menu-requested(x, y); }
             frame-requested => { root.frame-requested(); }

--- a/app/ui/tab-controls.slint
+++ b/app/ui/tab-controls.slint
@@ -92,6 +92,54 @@ export component MinimapToolButton inherits Rectangle {
     }
 }
 
+export component FolderToolButton inherits Rectangle {
+    in property <string> tooltip-text: "";
+    in property <bool> enabled: true;
+    out property <bool> hovered: touch.has-hover;
+    callback clicked();
+    callback secondary-clicked(length, length);
+
+    width: 32px;
+    height: 28px;
+    border-radius: 3px;
+    background: touch.has-hover && enabled ? Theme.surface-hover : transparent;
+
+    property <color> icon-color: root.enabled ? Theme.text-primary : Theme.text-secondary;
+
+    touch := TouchArea {
+        enabled: root.enabled;
+        clicked => { root.clicked(); }
+
+        pointer-event(e) => {
+            if e.kind == PointerEventKind.down && e.button == PointerEventButton.right {
+                root.secondary-clicked(self.absolute-position.x + self.mouse-x, self.absolute-position.y + self.mouse-y);
+            }
+        }
+    }
+
+    Path {
+        width: 18px;
+        height: 14px;
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+        stroke: root.icon-color;
+        stroke-width: 1.3px;
+        fill: transparent;
+        commands: "M 1 4 L 7 4 L 8.8 6 L 17 6 L 17 13 L 1 13 Z";
+    }
+
+    Path {
+        width: 18px;
+        height: 14px;
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+        stroke: root.icon-color;
+        stroke-width: 1.3px;
+        fill: transparent;
+        commands: "M 2 4 L 5 1 L 10 1 L 12 4";
+    }
+}
+
 export component MetadataToolButton inherits Rectangle {
     in property <string> tooltip-text;
     in property <bool> is-active: false;
@@ -151,6 +199,37 @@ export component MetadataToolButton inherits Rectangle {
     }
 }
 
+export component MeasureToolButton inherits Rectangle {
+    in property <string> tooltip-text;
+    in property <bool> is-active: false;
+    in property <bool> enabled: true;
+    out property <bool> hovered: touch.has-hover;
+    callback clicked();
+
+    width: 32px;
+    height: 28px;
+    border-radius: 3px;
+    background: is-active ? Theme.accent : (touch.has-hover && enabled ? Theme.surface-hover : transparent);
+
+    property <color> icon-color: root.enabled ? (root.is-active ? white : Theme.text-primary) : Theme.text-secondary;
+
+    touch := TouchArea {
+        enabled: root.enabled;
+        clicked => { root.clicked(); }
+    }
+
+    Path {
+        width: 17px;
+        height: 17px;
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+        stroke: root.icon-color;
+        stroke-width: 1.4px;
+        fill: transparent;
+        commands: "M 2 14 L 14 2 M 5 11 L 7 13 M 8 8 L 10 10 M 11 5 L 13 7";
+    }
+}
+
 export component RoiToolButton inherits Rectangle {
     in property <string> tooltip-text;
     in property <bool> is-active: false;
@@ -192,6 +271,43 @@ export component RoiToolButton inherits Rectangle {
         Rectangle { x: 15px; y: 0px; width: 1px; height: 3px; background: root.icon-color; }
         Rectangle { x: 15px; y: 5px; width: 1px; height: 3px; background: root.icon-color; }
         Rectangle { x: 15px; y: 9px; width: 1px; height: 3px; background: root.icon-color; }
+    }
+}
+
+export component ZoomInToolButton inherits Rectangle {
+    in property <string> tooltip-text: "";
+    in property <bool> enabled: true;
+    out property <bool> hovered: touch.has-hover;
+    callback clicked();
+
+    width: 32px;
+    height: 28px;
+    border-radius: 3px;
+    background: touch.has-hover && enabled ? Theme.surface-hover : transparent;
+
+    property <color> icon-color: root.enabled ? Theme.text-primary : Theme.text-secondary;
+
+    touch := TouchArea {
+        enabled: root.enabled;
+        clicked => { root.clicked(); }
+    }
+
+    Rectangle {
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+        width: 13px;
+        height: 1.4px;
+        border-radius: 1px;
+        background: root.icon-color;
+    }
+
+    Rectangle {
+        x: (parent.width - self.width) / 2;
+        y: (parent.height - self.height) / 2;
+        width: 1.4px;
+        height: 13px;
+        border-radius: 1px;
+        background: root.icon-color;
     }
 }
 

--- a/app/ui/window-toolbar.slint
+++ b/app/ui/window-toolbar.slint
@@ -1,6 +1,6 @@
 import { Theme } from "theme.slint";
 import { RenderMode, ToolType } from "types.slint";
-import { IconButton, MetadataToolButton, MinimapToolButton, RoiToolButton, ToolButton } from "tab-controls.slint";
+import { FolderToolButton, IconButton, MeasureToolButton, MetadataToolButton, MinimapToolButton, RoiToolButton, ToolButton, ZoomInToolButton } from "tab-controls.slint";
 
 export component WindowToolbar inherits Rectangle {
     in property <ToolType> current-tool: ToolType.navigate;
@@ -97,8 +97,7 @@ export component WindowToolbar inherits Rectangle {
         action-cluster := HorizontalLayout {
             spacing: 4px;
 
-            open-button := IconButton {
-                text: "📂";
+            open-button := FolderToolButton {
                 tooltip-text: "Open file (right-click for recent)";
                 clicked => { root.open-file-requested(); }
                 secondary-clicked(x, y) => { root.open-recent-menu-requested(x, y); }
@@ -110,8 +109,7 @@ export component WindowToolbar inherits Rectangle {
                 clicked => { root.frame-requested(); }
             }
 
-            zoom-in-button := IconButton {
-                text: "+";
+            zoom-in-button := ZoomInToolButton {
                 tooltip-text: "Zoom in";
                 clicked => { root.zoom-in-requested(); }
             }
@@ -148,8 +146,7 @@ export component WindowToolbar inherits Rectangle {
                 clicked => { root.tool-selected(ToolType.region-of-interest); }
             }
 
-            measure-button := ToolButton {
-                icon: "📏";
+            measure-button := MeasureToolButton {
                 tooltip-text: "Measure distance";
                 is-active: root.current-tool == ToolType.measure-distance;
                 clicked => { root.tool-selected(ToolType.measure-distance); }

--- a/app/ui/window-toolbar.slint
+++ b/app/ui/window-toolbar.slint
@@ -8,6 +8,7 @@ export component WindowToolbar inherits Rectangle {
     in property <bool> gpu-rendering-available: false;
     in property <bool> show-minimap: true;
     in property <bool> show-metadata: false;
+    in property <bool> use-native-window-controls: false;
 
     callback open-file-requested();
     callback open-recent-menu-requested(length, length);
@@ -36,9 +37,9 @@ export component WindowToolbar inherits Rectangle {
         : cpu-button.hovered ? cpu-button.tooltip-text
         : gpu-button.hovered ? gpu-button.tooltip-text
         : metadata-button.hovered ? metadata-button.tooltip-text
-        : minimize-touch.has-hover ? "Minimize window"
-        : maximize-touch.has-hover ? "Maximize window"
-        : close-win-touch.has-hover ? "Close window"
+        : !root.use-native-window-controls && minimize-touch.has-hover ? "Minimize window"
+        : !root.use-native-window-controls && maximize-touch.has-hover ? "Maximize window"
+        : !root.use-native-window-controls && close-win-touch.has-hover ? "Close window"
         : "";
     out property <length> hovered-tooltip-center-x:
         open-button.hovered ? open-button.absolute-position.x + open-button.width / 2
@@ -52,9 +53,9 @@ export component WindowToolbar inherits Rectangle {
         : cpu-button.hovered ? cpu-button.absolute-position.x + cpu-button.width / 2
         : gpu-button.hovered ? gpu-button.absolute-position.x + gpu-button.width / 2
         : metadata-button.hovered ? metadata-button.absolute-position.x + metadata-button.width / 2
-        : minimize-touch.has-hover ? minimize-control.absolute-position.x + minimize-control.width / 2
-        : maximize-touch.has-hover ? maximize-control.absolute-position.x + maximize-control.width / 2
-        : close-win-touch.has-hover ? close-control.absolute-position.x + close-control.width / 2
+        : !root.use-native-window-controls && minimize-touch.has-hover ? minimize-control.absolute-position.x + minimize-control.width / 2
+        : !root.use-native-window-controls && maximize-touch.has-hover ? maximize-control.absolute-position.x + maximize-control.width / 2
+        : !root.use-native-window-controls && close-win-touch.has-hover ? close-control.absolute-position.x + close-control.width / 2
         : 0px;
     out property <length> hovered-tooltip-top-y:
         open-button.hovered ? open-button.absolute-position.y + open-button.height + 6px
@@ -68,9 +69,9 @@ export component WindowToolbar inherits Rectangle {
         : cpu-button.hovered ? cpu-button.absolute-position.y + cpu-button.height + 6px
         : gpu-button.hovered ? gpu-button.absolute-position.y + gpu-button.height + 6px
         : metadata-button.hovered ? metadata-button.absolute-position.y + metadata-button.height + 6px
-        : minimize-touch.has-hover ? minimize-control.absolute-position.y + minimize-control.height + 6px
-        : maximize-touch.has-hover ? maximize-control.absolute-position.y + maximize-control.height + 6px
-        : close-win-touch.has-hover ? close-control.absolute-position.y + close-control.height + 6px
+        : !root.use-native-window-controls && minimize-touch.has-hover ? minimize-control.absolute-position.y + minimize-control.height + 6px
+        : !root.use-native-window-controls && maximize-touch.has-hover ? maximize-control.absolute-position.y + maximize-control.height + 6px
+        : !root.use-native-window-controls && close-win-touch.has-hover ? close-control.absolute-position.y + close-control.height + 6px
         : 0px;
 
     height: 40px;
@@ -87,6 +88,11 @@ export component WindowToolbar inherits Rectangle {
     HorizontalLayout {
         padding: 4px;
         spacing: 4px;
+
+        Rectangle {
+            visible: root.use-native-window-controls;
+            width: root.use-native-window-controls ? 74px : 0px;
+        }
 
         action-cluster := HorizontalLayout {
             spacing: 4px;
@@ -198,6 +204,7 @@ export component WindowToolbar inherits Rectangle {
         minimize-control := Rectangle {
             width: 46px;
             height: 32px;
+            visible: !root.use-native-window-controls;
             background: minimize-touch.has-hover ? Theme.surface-hover : transparent;
             border-radius: 0px;
 
@@ -217,6 +224,7 @@ export component WindowToolbar inherits Rectangle {
         maximize-control := Rectangle {
             width: 46px;
             height: 32px;
+            visible: !root.use-native-window-controls;
             background: maximize-touch.has-hover ? Theme.surface-hover : transparent;
             border-radius: 0px;
 
@@ -236,6 +244,7 @@ export component WindowToolbar inherits Rectangle {
         close-control := Rectangle {
             width: 46px;
             height: 32px;
+            visible: !root.use-native-window-controls;
             background: close-win-touch.has-hover ? #e81123 : transparent;
             border-radius: 0px;
 


### PR DESCRIPTION
## Summary
- use macOS native traffic-light window controls with a transparent full-size titlebar
- reserve left toolbar space for the native controls and hide the custom right-side window buttons on macOS
- keep the existing custom frameless controls on non-macOS platforms

## Testing
- `LIBRARY_PATH=/opt/homebrew/lib cargo build --bin eov`
- `LIBRARY_PATH=/opt/homebrew/lib cargo test --workspace`
- macOS GUI smoke test with `target/debug/eov --gpu .../default.svs`